### PR TITLE
Accept messages with empty text

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -282,7 +282,7 @@ export class Slack {
 		if (data.subtype === "message_replied" && !data.files) {
 			return;
 		}
-		if (data.text && !data.text.startsWith("\ufff0")) {
+		if (data.text !== null && !data.text.startsWith("\ufff0")) {
 			// send a normal message, if present
 			const { msg, html } = await SlackMessageParser.parse(parserOpts, data.text, data.attachments);
 			const opts = {


### PR DESCRIPTION
Some bots send messages without text and add pretext/text etc as attachments to a message, which are handled by SlackMessageParser

Without this change, some bot messages are silently ignored