### PR TITLE
Fix crash on user_change event without user info

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -118,7 +118,9 @@ export class Client extends EventEmitter {
 			});
 
 			this.rtm.on("user_change", (data) => {
-				this.updateUser(data.user);
+				if (data.user) {
+					this.updateUser(data.user);
+				}
 			});
 
 			this.rtm.on("user_typing", (data) => {


### PR DESCRIPTION
Workaround for bug where an account is disabled on a shared workspace.

Fixes #13

(did this on mobile, I hope that at least the indentation went fine)