### PR TITLE
Add support for OAuth login

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -9,6 +9,19 @@ bridge:
   # Reachable URL of the Matrix homeserver
   homeserverUrl: https://matrix.org
 
+# Slack OAuth settings. Create a slack app at https://api.slack.com/apps
+oauth:
+  enabled: false
+  # Slack app credentials.
+  # N.B. This must be quoted so YAML wouldn't parse it as a float.
+  clientId: "242181311531.253471660323"
+  clientSecret: b3561066aa9af814155a12d33d9a28be
+  # Path where to listen for OAuth redirect callbacks.
+  redirectPath: /slack/oauth
+  # Set up proxying from https://your.domain/redirect_path to http://bindAddress:port/redirect_path,
+  # then set this field and the Slack app redirect URI field to the former.
+  redirectUri: https://your.domain/slack/oauth
+
 presence:
   # Bridge Discord online/offline status
   enabled: true

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,21 @@
+export class SlackConfigWrap {
+	public oauth: OAuthConfig = new OAuthConfig();
+
+	public applyConfig(newConfig: {[key: string]: any}, configLayer: {[key: string]: any} = this) {
+		Object.keys(newConfig).forEach((key) => {
+			if (configLayer[key] instanceof Object && !(configLayer[key] instanceof Array)) {
+				this.applyConfig(newConfig[key], configLayer[key]);
+			} else {
+				configLayer[key] = newConfig[key];
+			}
+		});
+	}
+}
+
+class OAuthConfig {
+	public enabled = false;
+	public clientId = "";
+	public clientSecret = "";
+	public redirectPath = "";
+	public redirectUri = "";
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from "express";
+import { WebClient } from "@slack/web-api";
+import { IRetData } from "mx-puppet-bridge";
+
+import {Config} from "./index";
+
+const forbidden = 403;
+const getHtmlResponse = (title, content) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Slack OAuth token</title>
+	<style>
+		body {
+			margin-top: 16px;
+			text-align: center;
+		}
+	</style>
+</head>
+<body>
+	<h4>${title}</h4>
+	<h2>${content}</h2>
+</body>
+</html>
+`;
+
+export const oauthCallback = async (req: Request, res: Response) => {
+	try {
+		const oauthData = await (new WebClient()).oauth.access({
+			client_id: Config().oauth.clientId,
+			client_secret: Config().oauth.clientSecret,
+			redirect_uri: Config().oauth.redirectUri,
+			// @ts-ignore
+			code: req.query.code,
+		});
+		res.send(getHtmlResponse(
+			`Your Slack token for ${oauthData.team_name} is`,
+			`<code>${oauthData.access_token}</code>`));
+	} catch (err) {
+		res.status(forbidden).send(getHtmlResponse("Failed to get OAuth token", err));
+	}
+};
+
+export const getDataFromStrHook = async (str: string): Promise<IRetData> => {
+	const retData = {
+		success: false,
+	} as IRetData;
+	if (!str) {
+		retData.error = "Please specify a token to link!";
+		if (Config().oauth.enabled) {
+			const oauthUrl = `https://slack.com/oauth/authorize?scope=client&client_id=${Config().oauth.clientId}`
+				+ `&redirect_uri=${encodeURIComponent(Config().oauth.redirectUri)}`;
+			retData.error += `\nYou can get a token via OAuth from ${oauthUrl}`;
+		}
+		return retData;
+	}
+	retData.success = true;
+	retData.data = {
+		token: str.trim(),
+	};
+	return retData;
+};

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { WebClient } from "@slack/web-api";
 import { IRetData } from "mx-puppet-bridge";
+import * as escapeHtml from "escape-html";
 
 import {Config} from "./index";
 
@@ -33,10 +34,10 @@ export const oauthCallback = async (req: Request, res: Response) => {
 			code: req.query.code,
 		});
 		res.send(getHtmlResponse(
-			`Your Slack token for ${oauthData.team_name} is`,
-			`<code>${oauthData.access_token}</code>`));
+			`Your Slack token for ${escapeHtml(oauthData.team_name)} is`,
+			`<code>${escapeHtml(oauthData.access_token)}</code>`));
 	} catch (err) {
-		res.status(forbidden).send(getHtmlResponse("Failed to get OAuth token", err));
+		res.status(forbidden).send(getHtmlResponse("Failed to get OAuth token", escapeHtml(err)));
 	}
 };
 


### PR DESCRIPTION
Flow:

0. Bridge admin configures bridge with slack app credentials and reverse proxying for oauth callback
1. User runs `link`
2. User clicks link in error message
3. User logs into Slack and accepts app
4. Slack redirects user to redirectPath, which shows the access token
5. User copies access token and runs `link <token>`

If `getDataFromStrHook` got the user's mxid, the last step could be automated, but this is good enough for now.

The app on Slack doesn't need to be configured to allow any specific scopes. It requests the `client` scope, which isn't visible in the slack app management scope selector, but it works anyway and it's somewhat documented at https://api.slack.com/scopes/client