### PR TITLE
display messages that only have attachments

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -362,11 +362,12 @@ export class App {
 		const parserOpts = this.getSlackMessageParserOpts(puppetId, msg.author.team);
 		log.verbose("Received message.");
 		const dedupeKey = `${puppetId};${params.room.roomId}`;
-		if (!(msg.empty || msg.attachments) &&
+		if (!(msg.empty && !msg.attachments) &&
 			!await this.messageDeduplicator.dedupe(dedupeKey, params.user.userId, params.eventId, msg.text || "")) {
 			const res = await this.slackMessageParser.FormatMessage(parserOpts, {
 				text: msg.text || "",
 				blocks: msg.blocks || undefined,
+				attachments: msg.attachments || undefined
 			});
 			const opts = {
 				body: res.body,


### PR DESCRIPTION
Not sure why this was not used since there is support in the parser, but at the moment messages from bots that only contain attachments do not get forwarded from Slack to Matrix.

This PR accepts messages with only attachments and passes attachments to the message parser.