### PR TITLE
add Matrix -> Slack slash command support

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -479,7 +479,7 @@ export class App {
 			event.content,
 		);
 
-		if (msg.text.startsWith("/")) {
+		if (msg.text.match(/^\/[0-9a-zA-Z]+/)) {
 			const [command, parameters] = msg.text.split(/ (.+)/);
 			chan.sendCommand(command, parameters)
 

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -480,15 +480,8 @@ export class App {
 		);
 
 		if (msg.text.startsWith("/")) {
-			let fullCommand = msg.text;
-			let commandParametersSplitPoint = fullCommand.indexOf(" ");
-			if (commandParametersSplitPoint < 0) {
-				chan.sendCommand(fullCommand, undefined)
-			} else {
-				let command = fullCommand.substr(0, commandParametersSplitPoint);
-				let parameters = fullCommand.substr(commandParametersSplitPoint + 1);
-				chan.sendCommand(command, parameters)
-			}
+			const [command, parameters] = msg.text.split(/ (.+)/);
+			chan.sendCommand(command, parameters)
 
 			return;
 		}

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -478,6 +478,21 @@ export class App {
 			this.getMatrixMessageParserOpts(room.puppetId),
 			event.content,
 		);
+
+		if (msg.text.startsWith("/")) {
+			let fullCommand = msg.text;
+			let commandParametersSplitPoint = fullCommand.indexOf(" ");
+			if (commandParametersSplitPoint < 0) {
+				chan.sendCommand(fullCommand, undefined)
+			} else {
+				let command = fullCommand.substr(0, commandParametersSplitPoint);
+				let parameters = fullCommand.substr(commandParametersSplitPoint + 1);
+				chan.sendCommand(command, parameters)
+			}
+
+			return;
+		}
+
 		if (asUser) {
 			if (data.emote) {
 				msg.text = `_${msg.text}_`;

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -481,7 +481,8 @@ export class App {
 
 		if (msg.text.match(/^\/[0-9a-zA-Z]+/)) {
 			const [command, parameters] = msg.text.split(/ (.+)/);
-			chan.sendCommand(command, parameters)
+			const eventId = await chan.sendCommand(command, parameters);
+			await this.puppet.eventSync.insert(room.puppetId, data.eventId!, eventId);
 
 			return;
 		}


### PR DESCRIPTION
Depends on https://github.com/Sorunome/soru-slack-client/pull/1 (do not merge until that PR is merged and soru-slack-client is updated in the package.json of this PR).

This PR allows users to send slack slash commands from Matrix to Slack by using double slash (for example `//me hello world`).

One thing to note is that this might only be supported by legacy tokens, according to https://github.com/ErikKalkoken/slackApiDoc. (I have not tested with OAuth, but it works with legacy tokens). Should we add some checks for that?

I've never done anything Matrix-related before, so please feel free to point any errors.
