### PR TITLE
remember thread ID from received messages

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -386,6 +386,7 @@ export class App {
 			if (msg.threadTs) {
 				const replyTs = this.threadSendTs[msg.threadTs] || msg.threadTs;
 				this.threadSendTs[msg.threadTs] = msg.ts;
+				this.tsThreads[msg.ts] = msg.threadTs
 				await this.puppet.sendReply(params, replyTs, opts);
 			} else {
 				await this.puppet.sendMessage(params, opts);


### PR DESCRIPTION
I've noticed that replying to received slack messages does not seem to work very well (most of my messages would just get sent into regular channel unless I reply to the root of the thread).

From what I can see, the issue was thread IDs not being saved from received messages. This PR fixes the issue.