### PR TITLE
allow encoded and unencoded d cookie for xoxc

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -65,7 +65,8 @@ export const getDataFromStrHook = async (str: string): Promise<IRetData> => {
 			retData.error = "Please specify the `d` cookie for `xoxc` tokens!";
 			return retData;
 		}
-		cookie = parts[1];
+		// first decode and then encode, in case the user input was already encoded
+		cookie = encodeURIComponent(decodeURIComponent(parts[1]));
 	}
 	if (token.startsWith("xox")) {
 		retData.success = true;


### PR DESCRIPTION
I think this fixes a common mistake.

Examples:
https://matrix.to/#/!uOjvskgRfNgksdiArw:sorunome.de/$S14cpVyK1ZcmYbk0HuL-_qnnGRSpe8UXF0ySOTPgAcg?via=sorunome.de&via=matrix.org&via=privacytools.io
https://matrix.to/#/!uOjvskgRfNgksdiArw:sorunome.de/$Q2EQ2zrWHMbaDCseZt8c3wO6N5eQvoZegW-0Ejm5-EQ?via=sorunome.de&via=matrix.org&via=privacytools.io