### PR TITLE
stop server after receiving SIGINT signal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,11 @@ async function run() {
 	});
 	await puppet.start();
 	puppet.AS.expressAppInstance.get(config.oauth.redirectPath, oauthCallback);
+
+	process.on('SIGINT', function () {
+		puppet.AS.stop()
+		process.exit(1)
+	})
 }
 
 // tslint:disable-next-line:no-floating-promises


### PR DESCRIPTION
Currently, pressing Ctrl+C does nothing when server is running, making developing a bit of a hassle. This fixes that issue.

One thing that bothers me though, is that `proces.exit` call. From what I see, `puppet.AS.stop()` should stop the server but it does not, so `process.exit` is still needed. I don't know the project's internals enough, maybe you can figure out how to stop more gracefully?