### PR TITLE
sample.config.yaml: mention mx-puppet-bridge/sample.config.yaml

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -1,3 +1,6 @@
+# For more generic bridge configuration options have a look at
+# https://github.com/Sorunome/mx-puppet-bridge/blob/master/sample.config.yaml
+
 bridge:
   # Port to host the bridge on
   # Used for communication between the homeserver and the bridge


### PR DESCRIPTION
Since the code and documentation is spread across two different repositories, mention that more sample configuration exists in the other repository.