### PR TITLE
Fix dockerfile, pinning node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:alpine AS builder
+FROM node:15.0-alpine3.12 AS builder
 
 WORKDIR /opt/mx-puppet-slack
 
-RUN apk --no-cache add git python make g++ pkgconfig \
+RUN apk --no-cache add git python2 make g++ pkgconfig \
     build-base \
     cairo-dev \
     jpeg-dev \
@@ -27,7 +27,7 @@ COPY --chown=node:node src/ ./src/
 RUN npm run build
 
 
-FROM node:alpine
+FROM node:15.0-alpine3.12
 
 VOLUME /data
 


### PR DESCRIPTION
or else build is broken
```
 => ERROR [builder 6/9] RUN npm install                                                                                                 80.7s 
------                                                                                                                                        
 > [builder 6/9] RUN npm install:                                                                                                             
#14 80.57 npm notice                                                                                                                          
#14 80.57 npm notice New minor version of npm available! 7.10.0 -> 7.11.1                                                                     
#14 80.57 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v7.11.1>                                                             
#14 80.57 npm notice Run `npm install -g npm@7.11.1` to update!                                                                               
#14 80.57 npm notice                                                                                                                          
#14 80.57 npm ERR! code 1
#14 80.57 npm ERR! path /opt/mx-puppet-slack/node_modules/better-sqlite3
#14 80.57 npm ERR! command failed
#14 80.57 npm ERR! command sh -c prebuild-install || npm run build-release
#14 80.57 npm ERR! > better-sqlite3@6.0.1 build-release
#14 80.57 npm ERR! > node-gyp rebuild --release
#14 80.57 npm ERR! 
#14 80.57 npm ERR! make: Entering directory '/opt/mx-puppet-slack/node_modules/better-sqlite3/build'
#14 80.57 npm ERR!   TOUCH b857c92884e9598d609f6be182a2595df7a8e00f.intermediate
#14 80.57 npm ERR!   ACTION deps_sqlite3_gyp_locate_sqlite3_target_extract_sqlite3 b857c92884e9598d609f6be182a2595df7a8e00f.intermediate
#14 80.57 npm ERR!   TOUCH Release/obj.target/deps/locate_sqlite3.stamp
#14 80.57 npm ERR!   CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
#14 80.57 npm ERR!   AR(target) Release/obj.target/deps/sqlite3.a
#14 80.57 npm ERR!   COPY Release/sqlite3.a
#14 80.57 npm ERR!   CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
#14 80.57 npm ERR! rm b857c92884e9598d609f6be182a2595df7a8e00f.intermediate
#14 80.57 npm ERR! make: Leaving directory '/opt/mx-puppet-slack/node_modules/better-sqlite3/build'
#14 80.57 npm ERR! gyp info it worked if it ends with ok
#14 80.57 npm ERR! gyp info using node-gyp@7.1.2
#14 80.57 npm ERR! gyp info using node@16.0.0 | linux | x64
#14 80.57 npm ERR! gyp info find Python using Python version 3.8.8 found at "/usr/bin/python3"
#14 80.57 npm ERR! gyp http GET https://unofficial-builds.nodejs.org/download/release/v16.0.0/node-v16.0.0-headers.tar.gz
#14 80.57 npm ERR! gyp http 200 https://unofficial-builds.nodejs.org/download/release/v16.0.0/node-v16.0.0-headers.tar.gz
#14 80.57 npm ERR! gyp http GET https://unofficial-builds.nodejs.org/download/release/v16.0.0/SHASUMS256.txt
#14 80.57 npm ERR! gyp http 200 https://unofficial-builds.nodejs.org/download/release/v16.0.0/SHASUMS256.txt
#14 80.57 npm ERR! (node:91) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
#14 80.57 npm ERR! (Use `node --trace-deprecation ...` to show where the warning was created)
#14 80.57 npm ERR! gyp info spawn /usr/bin/python3
#14 80.57 npm ERR! gyp info spawn args [
#14 80.57 npm ERR! gyp info spawn args   '/usr/local/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
#14 80.57 npm ERR! gyp info spawn args   'binding.gyp',
#14 80.57 npm ERR! gyp info spawn args   '-f',
#14 80.57 npm ERR! gyp info spawn args   'make',
#14 80.57 npm ERR! gyp info spawn args   '-I',
#14 80.57 npm ERR! gyp info spawn args   '/opt/mx-puppet-slack/node_modules/better-sqlite3/build/config.gypi',
#14 80.57 npm ERR! gyp info spawn args   '-I',
#14 80.57 npm ERR! gyp info spawn args   '/usr/local/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
#14 80.57 npm ERR! gyp info spawn args   '-I',
#14 80.57 npm ERR! gyp info spawn args   '/home/node/.cache/node-gyp/16.0.0/include/node/common.gypi',
...
```
